### PR TITLE
Roll-up of several fixes for the latest nightly

### DIFF
--- a/src/claims.rs
+++ b/src/claims.rs
@@ -1,3 +1,4 @@
+use std::borrow::{BorrowFrom, ToOwned};
 use std::collections::BTreeMap;
 
 use serialize::base64;
@@ -73,20 +74,20 @@ impl Claims {
     }
 
     /// Get the value of a claim.
-    pub fn get<K: StrAllocating>(&self, key: K) -> Option<&json::Json> {
-        self.raw.get(&key.into_string())
+    pub fn get<Sized? K: BorrowFrom<String>+Ord>(&self, key: &K) -> Option<&json::Json> {
+        self.raw.get(BorrowFrom::borrow_from(key))
     }
 
     /// Add a (potentially unregistered) claim. Note that this can lead
     /// to an invalid JWT if the semantics of the claim don't match the
     /// JWT specification.
-    pub fn insert_unsafe<K: StrAllocating, V: ToJson>(&mut self, key: K, value: V) {
-        self.raw.insert(key.into_string(), value.to_json());
+    pub fn insert_unsafe<V: ToJson>(&mut self, key: &str, value: V) {
+        self.raw.insert(key.to_owned(), value.to_json());
     }
 
     /// Remove a claim.
-    pub fn remove<K: StrAllocating>(&mut self, key: K) -> Option<json::Json> {
-        self.raw.remove(&key.into_string())
+    pub fn remove<Sized? K: BorrowFrom<String>+Ord>(&mut self, key: &K) -> Option<json::Json> {
+        self.raw.remove(BorrowFrom::borrow_from(key))
     }
 }
 

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -1,10 +1,10 @@
 use std::borrow::{BorrowFrom, ToOwned};
 use std::collections::BTreeMap;
 
-use serialize::base64;
-use serialize::base64::ToBase64;
-use serialize::json;
-use serialize::json::ToJson;
+use rustc_serialize::base64;
+use rustc_serialize::base64::ToBase64;
+use rustc_serialize::json;
+use rustc_serialize::json::ToJson;
 
 /// A set of JWT claims.
 #[deriving(PartialEq, Show)]

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -1,4 +1,4 @@
-use std::collections::TreeMap;
+use std::collections::BTreeMap;
 
 use serialize::base64;
 use serialize::base64::ToBase64;
@@ -9,13 +9,13 @@ use serialize::json::ToJson;
 #[deriving(PartialEq, Show)]
 pub struct Claims {
     /// Raw JSON contents of the claims. This may become private.
-    pub raw: TreeMap<String, json::Json>,
+    pub raw: BTreeMap<String, json::Json>,
 }
 
 impl Claims {
     /// Create an empty claim set.
     pub fn new() -> Claims {
-        Claims { raw: TreeMap::new() }
+        Claims { raw: BTreeMap::new() }
     }
 
     /// Who issued the JWT.

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -6,9 +6,9 @@
 use std::str;
 use std::error::{Error, FromError};
 
-use serialize::base64;
-use serialize::base64::{ToBase64, FromBase64};
-use serialize::json;
+use rustc_serialize::base64;
+use rustc_serialize::base64::{ToBase64, FromBase64};
+use rustc_serialize::json;
 
 use claims::Claims;
 use util::safe_cmp;

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -68,7 +68,7 @@ fn decode_generic(input: &str,
         return Err(DecodeError::InvalidSignature);
     }
     let payload_bytes = try!(parts[1].from_base64());
-    let payload_str = try_option!(str::from_utf8(&*payload_bytes), DecodeError::Malformed);
+    let payload_str = try_option!(str::from_utf8(&*payload_bytes).ok(), DecodeError::Malformed);
     let payload = try!(json::from_str(payload_str));
     let claims = Claims { raw: try_option!(payload.as_object(), DecodeError::Malformed).clone() };
     Ok(claims)

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -137,6 +137,7 @@ pub mod hs256 {
         fn test_decode() {
             let claims = decode(TEST_TOKEN, b"secret").unwrap();
             assert_eq!(2, claims.raw.len());
+			assert_eq!(Some("value"), claims.get("com.example.my").and_then(|v| v.as_string()));
             assert_eq!(Some("value"), claims.raw["com.example.my".to_string()].as_string());
             assert_eq!(Some("urn:someone"), claims.sub());
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 #![feature(macro_rules)]
 
 extern crate time;
-extern crate serialize;
+extern crate "rustc-serialize" as rustc_serialize;
 extern crate openssl;
 
 pub use claims::Claims;


### PR DESCRIPTION
The commit messages are pretty self explanatory; but this fixes a number of issues that have been introduced by the latest round of nightlies.

1. Certain macros need to be changed; they are parsed as expressions unless followed by a trailing semicolon.
2. TreeMap moved out of tree to `collect-rs`... however `BTreeMap` is a pretty suitable replacement; and it's almost certainly what you want to use here. (It's what `serialize::json` uses internally now.)
3. `StrAllocating` is gone and merged into `StrExt` -- however `into_string()` is also deprecated.
    * StrAllocating is replaced by the more powerful `BorrowFrom<T>`
    * A test is added for `get(&str)` (`remove(&str)` works the same way...)
    * `insert()` uses `ToOwned<String>#to_owned()` instead of `into_string()` -- they perform the same function; it just moved to a more flexible trait.
4. UTF-8 parsing functions return `Result<String, Utf8Error>` now, so to use it with your `try_option!` macro we just call `.ok()` to convert it to an `Option<String>`
5. `libserialize` has moved out of tree; I have adjusted the library imports accordingly.

Lemme know how it looks. Passes checks on my machine w/ `rustc 0.13.0-nightly (62fb41c32 2014-12-23 02:41:48 +0000)`

